### PR TITLE
fix_CUDNN_STATUS_NOT_SUPPORTED

### DIFF
--- a/graph_ter_cls/tools/utils.py
+++ b/graph_ter_cls/tools/utils.py
@@ -60,7 +60,7 @@ def get_edge_feature(x, k=20):
     feature = x.view(batch_size * num_points, -1)[indices, :]
     feature = feature.view(batch_size, num_points, k, num_feats)
     x = x.view(batch_size, num_points, 1, num_feats).repeat(1, 1, k, 1)
-    feature = torch.cat((feature - x, x), dim=3).permute(0, 3, 1, 2)
+    feature = torch.cat((feature - x, x), dim=3).permute(0, 3, 1, 2).contiguous()
     return feature
 
 

--- a/graph_ter_seg/models/classifier.py
+++ b/graph_ter_seg/models/classifier.py
@@ -47,7 +47,7 @@ class Classifier(nn.Module):
         features = features.repeat(1, 1, self.num_points)
         features = torch.cat((features, x), dim=1)
         features = self.classifier(features)
-        features = features.permute(0, 2, 1)
+        features = features.permute(0, 2, 1).contiguous()
         features = F.log_softmax(features, dim=-1)
         return features
 

--- a/graph_ter_seg/tools/utils.py
+++ b/graph_ter_seg/tools/utils.py
@@ -61,7 +61,7 @@ def get_edge_feature(x, k=20):
     feature = x.view(batch_size * num_points, -1)[indices, :]
     feature = feature.view(batch_size, num_points, k, num_feats)
     x = x.view(batch_size, num_points, 1, num_feats).repeat(1, 1, k, 1)
-    feature = torch.cat((feature - x, x), dim=3).permute(0, 3, 1, 2)
+    feature = torch.cat((feature - x, x), dim=3).permute(0, 3, 1, 2).contiguous()
     return feature
 
 


### PR DESCRIPTION
by adding .contiguous() after all permute function, pytorch version no longer limited to <= 1.2.0.